### PR TITLE
MariaDB / Session Token / Unit Testing 

### DIFF
--- a/Scenes/Singletons/Server.gd
+++ b/Scenes/Singletons/Server.gd
@@ -105,6 +105,7 @@ remote func DespawnPlayer(player_id):
 	get_node("../SceneHandler/Map").DespawnPlayer(player_id)
 
 func cw_MeleeAttack(blend_position):
+	TestAuthUsingPlayerID()
 	rpc_id(1, "cw_MeleeAttack", blend_position)
 
 remote func ReceiveEnemyAttack(enemy_id, attack_type):


### PR DESCRIPTION
## Description

Removed SQLite
Added MariaDB
Compiled 3.3.4 with Sigrud MariaDB extension
AuthServer now needs to be run off the new compiled exe
Changed all SQLite code to MariaDB code
Removed old session token and replaced it with the rpc_get_sender_id() as this is randomly generated each time a player logs in.
Added Unit Testing for Player Account features
- Create Account
- Delete Account
- Add Session Token
- Remove Session Token
Added new column in playeraccounts table "can_login" 0=banned, 1="unrestricted"
Changed name of column in playeraccounts from "ID" to "account_id" this is the primary key
Change name of column in playerinventories from "player_id" to "account_id"
Added instruction in readme on how to get this version up and running effortlessly


## Motivation

SQLite bad - MariaDB good. 
Session token for verifying play actions on the server (more secure / less cheating)
Unit testing because this project now needs it and Czolzen added it 
Changed the names to be less confusing about what they really are

## Testing

Unit tests run as above. 
Manually create account 
Manually log into account
