### PR TITLE
Several fixes

### DIFF
--- a/Scenes/Enemies/Mino.gd
+++ b/Scenes/Enemies/Mino.gd
@@ -1,13 +1,5 @@
 extends KinematicBody2D
 
-enum STATES{
-	IDLE, 
-	WANDER, 
-	CHASE, 
-	ATTACK, 
-	DEAD
-}
-
 enum ATTACK_TYPES {
 	ATTACKSWING,
 	ATTACKSPIN,
@@ -24,7 +16,6 @@ var velocity = Vector2.ZERO
 var blend_position = Vector2.ZERO
 var facing_blend_position = Vector2.ZERO
 var rng
-var state = STATES.IDLE
 var attacking = false
 var current_position
 var attack_type = ""
@@ -45,17 +36,6 @@ func _physics_process(delta):
 		queue_free()
 	
 	blend_position()
-	match state:
-		STATES.IDLE:
-			pass
-		STATES.WANDER:
-			pass
-		STATES.CHASE:
-			pass
-		STATES.ATTACK:
-			pass
-		STATES.DEAD:
-			queue_free()
 	
 func MoveEnemy(new_position):
 	if attack_timer.is_stopped():

--- a/Scenes/Enemies/Slime.gd
+++ b/Scenes/Enemies/Slime.gd
@@ -3,17 +3,12 @@ extends KinematicBody2D
 
 var max_hp	= 9000
 var current_hp = 9000
-var state
 var type
 var dead = false
 func _ready():
 	$AnimationPlayer.play("slimeAnimation")
 	$HealthBar.max_value = max_hp
 	$HealthBar.value = current_hp
-	if state == "Idle":
-		pass
-	elif state == "Dead":
-		OnDeath()
 	$FloatAroundAnimation.play("Float")
 		#hide health bar and hitboes here later
 

--- a/Scenes/Enemy.gd
+++ b/Scenes/Enemy.gd
@@ -3,17 +3,12 @@ extends KinematicBody2D
 
 var max_hp	
 var current_hp
-var state
 var type
 
 func _ready():
 	$HealthBar.max_value = max_hp
 	$HealthBar.value = current_hp
 	$Rekt.visible = false
-	if state == "Idle":
-		pass
-	elif state == "Dead":
-		OnDeath()
 		#hide health bar and hitboes here later
 
 func _physics_process(delta):

--- a/Scenes/Maps/Map.gd
+++ b/Scenes/Maps/Map.gd
@@ -37,6 +37,8 @@ func _unhandled_input(event):
 			next_background_music_track()
 		if event.pressed and event.is_action_pressed("PreviousBackgroundMusic"):
 			previous_background_music_track()
+		if event.pressed and event.is_action_pressed("Inventory"):
+			$GUI/Inventory.visible = !$GUI/Inventory.visible
 
 func play_background_music():
 	background_music.stream = load("res://Assets/Sounds/Background Music/" + tracks[track_playing])
@@ -86,7 +88,7 @@ func SpawnNewEnemy(enemy_id, enemy_dict):
 	new_enemy.max_hp = enemy_dict[g.ENEMY_MAX_HEALTH]
 	new_enemy.current_hp = enemy_dict[g.ENEMY_CURRENT_HEALTH]
 	new_enemy.type = enemy_dict[g.ENEMY_TYPE]
-	new_enemy.state = enemy_dict[g.ENEMY_STATE]
+	#new_enemy.state = enemy_dict[g.ENEMY_STATE]
 	new_enemy.name = str(enemy_id)
 	if new_enemy.current_hp > 0:
 		get_node("YSort/Enemies/").add_child(new_enemy, true)

--- a/Scenes/Maps/Map.tscn
+++ b/Scenes/Maps/Map.tscn
@@ -1108,6 +1108,7 @@ position = Vector2( 779.727, 488.088 )
 position = Vector2( 190.819, 359.188 )
 
 [node name="Inventory" parent="GUI" instance=ExtResource( 11 )]
+visible = false
 
 [node name="PlayerStats" parent="GUI" instance=ExtResource( 7 )]
 visible = false

--- a/Scenes/Singletons/Server.gd
+++ b/Scenes/Singletons/Server.gd
@@ -106,7 +106,6 @@ remote func DespawnPlayer(player_id):
 
 func cw_MeleeAttack(blend_position):
 	rpc_id(1, "cw_MeleeAttack", blend_position)
-	print(ItemDatabase.all_item_data[0])
 
 remote func ReceiveEnemyAttack(enemy_id, attack_type):
 	if get_node("../SceneHandler/Map/YSort/Enemies/").has_node(str(enemy_id)):

--- a/project.godot
+++ b/project.godot
@@ -76,6 +76,11 @@ PreviousBackgroundMusic={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
  ]
 }
+Inventory={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":73,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [input_devices]
 


### PR DESCRIPTION
## Description

This contains several fixes:
 - Removed printing inventory on attack (would crash Client if run from Editor)
 - Removed all references to Enemy state (this should be added back in future commits - also caused crashing in Editor)
 - Inventory screen is now hidden by default, can be toggled by pressing "I"

## Motivation

Cleanup + fix debug runs

## Testing

GIF
![test13](https://user-images.githubusercontent.com/16952886/139871284-c22bbd02-78ae-4089-9a66-2c0fa68d69e3.gif)
:
