### PR TITLE
Inventory persistence

### DIFF
--- a/Scenes/Singletons/Server.gd
+++ b/Scenes/Singletons/Server.gd
@@ -4,6 +4,9 @@
 ###############################################
 
 extends Node
+signal item_swap_ok
+signal item_swap_nok
+signal item_swap_blocked
 
 var network = NetworkedMultiplayerENet.new()
 #var ip = "192.99.247.42"
@@ -113,5 +116,14 @@ remote func ReceiveEnemyAttack(enemy_id, attack_type):
 
 remote func ReceivePlayerInventory(inventory_data):
 	var PlayerInventory = get_node("/root/SceneHandler/Map/GUI/Inventory")
-	PlayerInventory.RefreshInventory(inventory_data[0])
+	PlayerInventory.RefreshInventory(inventory_data)
 
+func swap_items(from, to):
+	emit_signal("item_swap_blocked")
+	rpc_id(1, "swap_items", from, to)
+	
+remote func item_swap_ok():
+	emit_signal("item_swap_ok")
+
+remote func item_swap_nok():
+	emit_signal("item_swap_nok")

--- a/Scenes/UI/Inventory/DragItems.gd
+++ b/Scenes/UI/Inventory/DragItems.gd
@@ -2,13 +2,19 @@ extends TextureRect
 
 export var item_slot : int
 var item_id = -1
+var awaiting_response = false
 var base_texture
+var drop_data_storage = null
+
 
 func _ready() -> void:
 	base_texture = texture
+	Server.connect("item_swap_ok", self, "handle_item_swap_ok")
+	Server.connect("item_swap_blocked", self, "handle_item_swap_blocked")
+	Server.connect("item_swap_nok", self, "handle_item_swap_nok")
 
 func get_drag_data(position: Vector2):
-	if item_id == -1:
+	if item_id == -1 or awaiting_response:
 		return null
 	var data = {}
 	data["origin_node"] = self
@@ -45,15 +51,32 @@ func can_drop_data(position: Vector2, data) -> bool:
 	return false
 	
 func drop_data(position: Vector2, data) -> void:
-	item_id = data["origin_item_id"]
-	if item_id != -1:
-		texture = data["origin_texture"]
+	drop_data_storage = data
+	# swap item_ids
 	data["origin_node"].item_id = data["destination_item_id"]
+	data["destination_node"].item_id = data["origin_item_id"]
+	
+	# swap textures
+	texture = data["origin_texture"]
 	if data["destination_item_id"] != -1:
 		data["origin_node"].texture = data["destination_texture"]
 	else:
 		data["origin_node"].set_base_texture()
-	
+		
+	# update world server
+	Server.swap_items(data["origin_slot_number"], item_slot)
+
+func reverse_swap():
+	if drop_data_storage != null:
+		var data = drop_data_storage
+		
+		# restore item_ids
+		data["origin_node"].item_id = data["origin_item_id"]
+		data["destination_node"].item_id = data["destination_item_id"]
+		
+		# restore textures
+		data["origin_node"].texture = data["origin_texture"]
+		data["destination_node"].texture = data["destination_texture"]
 
 func AllowSwitch(origin_item_slot, origin_item_category_id, destination_item_slot, destination_item_category_id):
 	var result : bool = ItemDatabase.item_fits_slot(origin_item_category_id, destination_item_slot)
@@ -64,3 +87,16 @@ func AllowSwitch(origin_item_slot, origin_item_category_id, destination_item_slo
 # This returns the original texture. Used to restore silhouettes in equipment
 func set_base_texture() -> void:
 	texture = base_texture
+
+func handle_item_swap_ok():
+	awaiting_response = false
+	drop_data_storage = null
+
+func handle_item_swap_blocked():
+	awaiting_response = true
+
+func handle_item_swap_nok():
+	reverse_swap()
+	awaiting_response = false
+	drop_data_storage = null
+	

--- a/Scenes/UI/Inventory/Inventory.gd
+++ b/Scenes/UI/Inventory/Inventory.gd
@@ -41,8 +41,7 @@ func _ready():
 
 func RefreshInventory(inventory_data):
 	print(["Inventory data: ", inventory_data])
-	for item in inventory_data:
-		var item_slot = int(item[0])
-		var item_id = int(item[1])
-		item_slots[item_slot].texture = item_textures[item_id]
-		item_slots[item_slot].item_id = item_id
+	for slot in inventory_data.keys():
+		var item_id = inventory_data[slot]["item_id"]
+		item_slots[slot].texture = item_textures[item_id]
+		item_slots[slot].item_id = item_id


### PR DESCRIPTION
## Description

 - updated inventory handling functions to reflect the type change from array to dictionary
 - Added synchronization between WorldServer and Client when an item is being moved in the inventory:
    - When Client moves an item in the inventory, it blocks all other item movement and awaits response from server.
    - When the response is received client unblocks all item movement
    - There is also functionality here which reverts item movement if its not accepted by the server but currently it is not used

## Motivation

Allow players to gain and equip items

## Testing

1. Create a new account and login
2. Open inventory, move some items around
3. Close client
4. Open client, log in
5. The items should be in the same slots you left them

GIF in preparation (dont merge before I upload)
![test16](https://user-images.githubusercontent.com/16952886/140075120-db180113-541b-4161-b969-81ea9591244b.gif)

