### PR TITLE
Monster item drop

### DIFF
--- a/Scenes/Maps/Map.gd
+++ b/Scenes/Maps/Map.gd
@@ -14,10 +14,12 @@ var slime = preload("res://Scenes/Enemies/Slime.tscn")
 var mino = preload("res://Scenes/Enemies/Mino.tscn")
 var player_spawn = preload("res://Scenes/Player/PlayerTemplate.tscn")
 var client_player = preload("res://Scenes/Player/Player.tscn")
+var item_drop = preload("res://Scenes/Props/ItemGround.tscn")
 var last_world_state = 0
 var world_state_buffer = []
 const interpolation_offset = 100
 var printed_world_state = false
+var item_textures : Dictionary = {}
 
 
 func _ready():
@@ -30,6 +32,8 @@ func _ready():
 			break
 		elif file.ends_with(".mp3"):
 			tracks.append(file)	
+	
+	LoadItemTextures()
 
 func _unhandled_input(event):
 	if event is InputEventKey:
@@ -102,6 +106,28 @@ func UpdateWorldState(world_state):
 	if world_state[g.TIMESTAMP] > last_world_state:
 		last_world_state = world_state[g.TIMESTAMP]
 		world_state_buffer.append(world_state)
+
+func DropItem(item_id, item_name, item_position):
+	var new_item_drop = item_drop.instance()
+	new_item_drop.name = item_name
+	new_item_drop.item_id = item_id
+	new_item_drop.position = item_position
+	new_item_drop.item_texture = item_textures[int(item_id)]
+	add_child(new_item_drop)
+
+func LoadItemTextures():
+	dir.open("res://Assets/inventory/Items/")
+	dir.list_dir_begin(true, true)
+	#get all files that end in .png from the directory above
+	while true:
+		var file = dir.get_next()
+		if file == "":
+			break
+		elif file.ends_with(".png") and file[0].to_int() != 0:
+			var id = file.to_int()
+			item_textures[id] =  load("res://Assets/inventory/Items/" + file)
+	
+
 		
 func _physics_process(_delta):
 	var render_time = Server.client_clock - interpolation_offset

--- a/Scenes/Props/ItemGround.gd
+++ b/Scenes/Props/ItemGround.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+var item_id : int 
+var item_texture : StreamTexture
+
+func _ready():
+	$Sprite.texture = item_texture
+	$RemoveTimer.start()
+	
+
+func _on_RemoveTimer_timeout():
+	queue_free()

--- a/Scenes/Props/ItemGround.tscn
+++ b/Scenes/Props/ItemGround.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Assets/inventory/Items/6_silver_sword.png" type="Texture" id=1]
+[ext_resource path="res://Scenes/Props/ItemGround.gd" type="Script" id=2]
+
+[sub_resource type="Animation" id=1]
+resource_name = "bounce"
+loop = true
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.5, 1 ),
+"transitions": PoolRealArray( 1, 1, 1 ),
+"update": 0,
+"values": [ Vector2( 0, 0 ), Vector2( 0, -15 ), Vector2( 0, 0 ) ]
+}
+
+[node name="ItemGround" type="Node2D"]
+script = ExtResource( 2 )
+
+[node name="Sprite" type="Sprite" parent="."]
+position = Vector2( 0, -14.5892 )
+texture = ExtResource( 1 )
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+root_node = NodePath("../Sprite")
+autoplay = "bounce"
+anims/bounce = SubResource( 1 )
+
+[node name="RemoveTimer" type="Timer" parent="."]
+wait_time = 5.0
+
+[connection signal="timeout" from="RemoveTimer" to="." method="_on_RemoveTimer_timeout"]

--- a/Scenes/Props/ItemGround.tscn
+++ b/Scenes/Props/ItemGround.tscn
@@ -23,7 +23,7 @@ tracks/0/keys = {
 script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="."]
-position = Vector2( 0, -14.5892 )
+position = Vector2( 0, -10.2426 )
 texture = ExtResource( 1 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/Scenes/Singletons/Gateway.gd
+++ b/Scenes/Singletons/Gateway.gd
@@ -5,6 +5,7 @@ var gateway_api = MultiplayerAPI.new()
 var port = 1910
 var online_ip = "192.99.247.42"
 var local_ip = "127.0.0.1"
+#var ip = "45.58.43.202"
 var ip = "127.0.0.1"
 var connected = false
 

--- a/Scenes/Singletons/ItemDatabase.gd
+++ b/Scenes/Singletons/ItemDatabase.gd
@@ -26,3 +26,4 @@ func item_category(item_id : int):
 	if item_id == -1:
 		return null
 	return int(all_item_data[item_id]["item_category"])
+

--- a/Scenes/Singletons/Server.gd
+++ b/Scenes/Singletons/Server.gd
@@ -10,6 +10,7 @@ signal item_swap_blocked
 
 var network = NetworkedMultiplayerENet.new()
 #var ip = "192.99.247.42"
+#var ip = "45.58.43.202"
 var ip = "127.0.0.1"
 var port = 1909
 
@@ -127,3 +128,7 @@ remote func item_swap_ok():
 
 remote func item_swap_nok():
 	emit_signal("item_swap_nok")
+	
+remote func AddItemDropToClient(item_id, item_name, item_position):
+	print("DROP ITEM")
+	get_node("../SceneHandler/Map").DropItem(randi() % 12 + 1, item_name, item_position)

--- a/Scenes/Singletons/Server.gd
+++ b/Scenes/Singletons/Server.gd
@@ -131,4 +131,4 @@ remote func item_swap_nok():
 	
 remote func AddItemDropToClient(item_id, item_name, item_position):
 	print("DROP ITEM")
-	get_node("../SceneHandler/Map").DropItem(randi() % 12 + 1, item_name, item_position)
+	get_node("../SceneHandler/Map").DropItem(item_id, item_name, item_position)


### PR DESCRIPTION
## Description

When a monster dies it drops an item now into the world.
Monsters have an item pool they can drop from (loot tables)
items are spawned on both world server and client. Only server has the hitbox to pickup the item.
Items are removed after x seconds (4 right now). 

TODO: 
-add player can pick up item
-attach playerid to item (last hit on mob)
-add item to inventory once picked up

## Motivation

what is an rpg without item drops?


## Testing
tested a bunch locally, see gif

https://user-images.githubusercontent.com/53924507/140466885-a4a42f6b-2c28-4808-aaa0-af53c9d12886.mp4


