### PR TITLE
added playerId to monsters, tagged system, item gets a player tag

### DIFF
--- a/Scenes/Maps/Map.gd
+++ b/Scenes/Maps/Map.gd
@@ -107,11 +107,12 @@ func UpdateWorldState(world_state):
 		last_world_state = world_state[g.TIMESTAMP]
 		world_state_buffer.append(world_state)
 
-func DropItem(item_id, item_name, item_position):
+func DropItem(item_id : int, item_name : String, item_position : Vector2, tagged_by_player : int):
 	var new_item_drop = item_drop.instance()
 	new_item_drop.name = item_name
 	new_item_drop.item_id = item_id
 	new_item_drop.position = item_position
+	new_item_drop.tagged_by_player = tagged_by_player
 	new_item_drop.item_texture = item_textures[int(item_id)]
 	get_node("YSort/Items").add_child(new_item_drop)
 

--- a/Scenes/Player/Player.gd
+++ b/Scenes/Player/Player.gd
@@ -17,6 +17,7 @@ var moving = false
 var player_state
 var player_action = IDLE
 var blend_position = Vector2.ZERO
+var player_id : int
 
 
 

--- a/Scenes/Props/ItemGround.gd
+++ b/Scenes/Props/ItemGround.gd
@@ -2,12 +2,19 @@ extends Node2D
 
 var item_id : int 
 var item_texture : StreamTexture
+var tagged_by_player : int
+var time_left_for_nonkiller_pickup : float = 5.0
 
 func _ready():
 	$Sprite.texture = item_texture
+	$PickupTimer.wait_time = time_left_for_nonkiller_pickup
+	print("tagged by", tagged_by_player)
+	if tagged_by_player != get_node("../../Player").player_id: 
+		$PickupTimer.start(time_left_for_nonkiller_pickup)
+		$Sprite.modulate.a = 0.5
 	
-	
-
 func RemoveFromWorld():
 	queue_free()
 
+func _on_PickupTimer_timeout() -> void:
+	$Sprite.modulate.a = 1

--- a/Scenes/Props/ItemGround.tscn
+++ b/Scenes/Props/ItemGround.tscn
@@ -30,3 +30,9 @@ texture = ExtResource( 1 )
 root_node = NodePath("../Sprite")
 autoplay = "bounce"
 anims/bounce = SubResource( 1 )
+
+[node name="PickupTimer" type="Timer" parent="."]
+wait_time = 10.0
+one_shot = true
+
+[connection signal="timeout" from="PickupTimer" to="." method="_on_PickupTimer_timeout"]

--- a/Scenes/Singletons/Server.gd
+++ b/Scenes/Singletons/Server.gd
@@ -129,9 +129,9 @@ remote func item_swap_ok():
 remote func item_swap_nok():
 	emit_signal("item_swap_nok")
 	
-remote func AddItemDropToClient(item_id, item_name, item_position):
+remote func AddItemDropToClient(item_id : int, item_name : String, item_position : Vector2, tagged_by_player : int):
 	print("DROP ITEM")
-	get_node("../SceneHandler/Map").DropItem(item_id, item_name, item_position)
+	get_node("../SceneHandler/Map").DropItem(item_id, item_name, item_position, tagged_by_player)
 
 remote func GetItemsOnGround(items_on_ground : Array):
 	print("Current items on ground before login: ", items_on_ground)
@@ -141,3 +141,5 @@ remote func GetItemsOnGround(items_on_ground : Array):
 remote func RemoveItemDropFromClient(item_name : String):
 	get_node("../SceneHandler/Map/YSort/Items/" + item_name).RemoveFromWorld()
 
+remote func StorePlayerID(player_id : int):
+	get_node("../SceneHandler/Map/YSort/Player").player_id = player_id


### PR DESCRIPTION
#IF YOU APPROVE MERGE THIS WITH CLIENT PR.
## Description
Added player-id to **player node** when they login . This allows the player to check their own playerid against playerids attached to items/monsters etc...
Added monster tagged feature: Monsters are tagged for X seconds when hit by a player. A timer starts and if it expires before it is hit by that same player again the player_id is removed from that monster (set to 0). If another player hits the enemy whilst the timer is running, the damage still happens but the player tag remains the same as the first player. 
This player_id tag on the monster can be used to award exp and kill credit but right now it is used to be attached to the item that the monster drops.
The client get rpc from world server with item and player_id of the killer. It then spawns the item into the world, if the item has the same player_id as the **player_node**, then the item appears as normal. If it is not the same (the player isnt the one who killed the monster), that item will appear transparent for X seconds determined by the server (TODO).

TODO: Item pick up
Send how long left on the server timer so client knows when to stop being transparent.


## Motivation

monster tagging is a part of most mmorpgs, and also player_id is handy to have for the future

## Testing


https://user-images.githubusercontent.com/53924507/140520634-01e64a15-5ddb-43ca-844d-4a0a162d6c7c.mp4

.
